### PR TITLE
http2: revert more of upstream http2 change

### DIFF
--- a/http2/transport_test.go
+++ b/http2/transport_test.go
@@ -3857,6 +3857,7 @@ func TestTransportRetryAfterGOAWAY(t *testing.T) {
 }
 
 func TestTransportRetryAfterRefusedStream(t *testing.T) {
+	t.Skip("broken by 82780d60 and later reverts; see https://github.com/golang/go/issues/60818 and https://github.com/tailscale/corp/issues/12296")
 	clientDone := make(chan struct{})
 	client := func(tr *Transport) {
 		defer close(clientDone)


### PR DESCRIPTION
Even the part we previously kept was bad. Revert all of 82780d60 but keep 6826f5a7db (which depended on bits of 82780d60). So this is a mix.

TestTransportRetryAfterRefusedStream fails with this change, but only because it was adjusted in 82780d60 to pass with 82780d60, and this test doesn't revert all the test changes. I just skip that test instead, because it doesn't really affect us.

Updates tailscale/corp#12296
Updates golang/go#60818